### PR TITLE
4章: デフォルトのtitle表示を設定

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+
+  def full_title(page_title = '')
+    base_title = 'Ruby on Rails Tutorial Sample App'
+    if page_title.empty?
+      base_title
+    else
+      "#{page_title} | #{base_title}"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta charset="utf-8">
     <%= csrf_meta_tags %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'Home') %>
-
 <div class="codespaces">
   <header class="codespaces-header">
     <img class="codespaces-logo"

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'static_pagesコントローラのテスト', type: :request do
       expect(response.status).to eq 200
     end
     it 'タイトルが正しく表示されること' do
-      expect(response.body).to include('<title>Home | Ruby on Rails Tutorial Sample App</title>')
+      expect(response.body).to include('<title>Ruby on Rails Tutorial Sample App</title>')
     end
   end
 


### PR DESCRIPTION
This pull request includes changes to improve the title handling in the application by introducing a helper method and updating the corresponding views and tests. The most important changes include the addition of the `full_title` helper method, updates to the layout and home view files, and modifications to the static pages spec.

Title handling improvements:

* [`app/helpers/application_helper.rb`](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daR2-R10): Added the `full_title` helper method to construct the full title based on the provided page title.
* [`app/views/layouts/application.html.erb`](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL4-R4): Updated the title tag to use the new `full_title` helper method.
* [`app/views/static_pages/home.html.erb`](diffhunk://#diff-6a8ea69ca566afd1812ab9732d330b9de4659d8c5163a8c4c5c6945177a13a9cL1-L2): Removed the `provide(:title, 'Home')` line as it is now handled by the `full_title` helper method.

Test updates:

* [`spec/requests/static_pages_spec.rb`](diffhunk://#diff-0c2fcb32d350102e3c555bddd5975683c99a0c2e6043b167c24d807b3b627088L12-R12): Modified the test to check for the correct title without the page-specific prefix, as handled by the `full_title` helper method.