### PR TITLE
Userモデルにパスワードを追加する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -146,3 +146,6 @@ NumericLiterals:
 
 AllCops:
   SuggestExtensions: false
+  Exclude:
+    - 'db/schema.rb'
+    - 'db/migrate/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -147,5 +147,6 @@ NumericLiterals:
 AllCops:
   SuggestExtensions: false
   Exclude:
+    - 'vendor/**/*' # Gem::MissingSpecError対策
     - 'db/schema.rb'
     - 'db/migrate/*'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.6'
 
-gem 'bootsnap',        '1.16.0', require: false
+gem 'bcrypt'
+gem 'bootsnap', '1.16.0', require: false
 gem 'bootstrap-sass',  '3.4.1'
 gem 'importmap-rails', '1.1.5'
 gem 'jbuilder',        '2.11.5'
@@ -11,9 +12,9 @@ gem 'puma',            '5.6.8'
 gem 'rails',           '7.0.4.3'
 gem 'sassc-rails',     '2.1.2'
 gem 'sprockets-rails', '3.4.2'
-gem 'sqlite3',         '1.6.1'
-gem 'stimulus-rails',  '1.2.1'
-gem 'turbo-rails',     '1.4.0'
+gem 'sqlite3', '1.6.1'
+gem 'stimulus-rails', '1.2.1'
+gem 'turbo-rails', '1.4.0'
 
 group :development, :test do
   gem 'debug', '1.7.1', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     backport (1.2.0)
+    bcrypt (3.1.20)
     benchmark (0.3.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -354,6 +355,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt
   bootsnap (= 1.16.0)
   bootstrap-sass (= 3.4.1)
   capybara

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
                     uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }
 
   has_secure_password
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
                     uniqueness: true
+
+  has_secure_password
 end

--- a/db/migrate/20250127070941_add_password_digest_to_users.rb
+++ b/db/migrate/20250127070941_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_27_062525) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_27_070941) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "password_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :user do
     name { "Example User" }
     email { "user@example.com" }
+    password { "P@ssw0rd" }
+    password_confirmation { "P@ssw0rd" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,5 +50,17 @@ RSpec.describe 'Userモデルのテスト', type: :model do
         expect(user.reload.email).to eq user.email.downcase
       end
     end
+    context 'passwordカラム' do
+      it '空欄でないこと' do
+        user.password = user.password_confirmation = ''
+        expect(user.valid?).to eq false
+      end
+      it '6文字以上であること' do
+        user.password = user.password_confirmation = 'a' * 6
+        expect(user.valid?).to eq true
+        user.password = user.password_confirmation = 'a' * 5
+        expect(user.valid?).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces password authentication to the user model, including validations, database changes, and tests. The most important changes are as follows:

### Authentication Enhancements:

* Added the `bcrypt` gem to the `Gemfile` to handle password encryption.
* Updated the `User` model to include password validations and the `has_secure_password` method.

### Database Modifications:

* Created a migration to add the `password_digest` column to the `users` table.
* Updated the `schema.rb` to reflect the new `password_digest` column in the `users` table.

### Testing:

* Updated the user factory to include password and password confirmation attributes.
* Added model tests to ensure password presence and length validations.