### PR TITLE
pry-railsを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sprockets-rails', '3.4.2'
 gem 'sqlite3', '1.6.1'
 gem 'stimulus-rails', '1.2.1'
 gem 'turbo-rails', '1.4.0'
+gem 'pry-rails'
 
 group :development, :test do
   gem 'debug', '1.7.1', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'bootsnap', '1.16.0', require: false
 gem 'bootstrap-sass',  '3.4.1'
 gem 'importmap-rails', '1.1.5'
 gem 'jbuilder',        '2.11.5'
+gem 'pry-rails'
 gem 'puma',            '5.6.8'
 gem 'rails',           '7.0.4.3'
 gem 'sassc-rails',     '2.1.2'
@@ -15,7 +16,6 @@ gem 'sprockets-rails', '3.4.2'
 gem 'sqlite3', '1.6.1'
 gem 'stimulus-rails', '1.2.1'
 gem 'turbo-rails', '1.4.0'
-gem 'pry-rails'
 
 group :development, :test do
   gem 'debug', '1.7.1', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.1)
@@ -366,6 +368,7 @@ DEPENDENCIES
   importmap-rails (= 1.1.5)
   irb (= 1.10.0)
   jbuilder (= 2.11.5)
+  pry-rails
   puma (= 5.6.8)
   rails (= 7.0.4.3)
   rails-controller-testing (= 1.0.5)


### PR DESCRIPTION
This pull request includes a small change to the `Gemfile`. The change adds the `pry-rails` gem to the list of dependencies.

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR18): Added `pry-rails` gem to the list of dependencies.